### PR TITLE
Do not trigger when a commit is pushed to a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ name: Semver PR Label Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled]
 
 jobs:
   run_semver_pr_label_check:


### PR DESCRIPTION
Do not trigger the Semver PR Label Check Workflow when a commit is pushed to a PR