### PR TITLE
Trigger Semver PR Label Check on PR synchronize

### DIFF
--- a/.github/workflows/semver_pr_label_check_self.yml
+++ b/.github/workflows/semver_pr_label_check_self.yml
@@ -3,7 +3,7 @@ name: Semver PR Label Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   run_semver_pr_label_check:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ name: Semver PR Label Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   run_semver_pr_label_check:


### PR DESCRIPTION
The PR synchronize trigger was removed in PR #8. 

Technically it is not necessary to check labels when the PR is synchronized since the labels don't change in this event.

However, if this check is not included, the check will be removed from the list of PR checks even if it had failed previously failed.

This will result in a false positive if all the other checks pass.

To avoid this, reverse the changes in PR #8 by adding the trigger back.