### PR TITLE
build: add conventional commit enforcement

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,16 @@
+---
+extends: '@commitlint/config-conventional'
+
+rules:
+  # See: https://commitlint.js.org/reference/rules.html
+  #
+  # Rules are made up by a name and a configuration array. The configuration array contains:
+  #
+  # * Severity [0..2]: 0 disable rule, 1 warning if violated, or 2 error if violated
+  # * Applicability [always|never]: never inverts the rule
+  # * Value: value to use for this rule
+  #
+  # Run `npx commitlint --print-config` to see the current setting for all rules.
+  #
+  body-leading-blank:    [2, 'always']
+  footer-leading-blank:  [2, 'always']

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -1,0 +1,21 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commit-lint:
+    name: Verify Conventional Commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Check Commit Messages
+        uses: wagoid/commitlint-github-action@v6
+        with: { configFile: .commitlintrc.yml }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no-install commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+<!--
+# @markup markdown
+# @title How To Contribute
+-->
+
+# Contributing to this project
+
+* [Summary](#summary)
+* [How to contribute](#how-to-contribute)
+* [How to report an issue or request a feature](#how-to-report-an-issue-or-request-a-feature)
+* [How to submit a code or documentation change](#how-to-submit-a-code-or-documentation-change)
+* [Design philosophy](#design-philosophy)
+* [Coding standards](#coding-standards)
+  * [Commit message guidelines](#commit-message-guidelines)
+  * [Pull request guidelines](#pull-request-guidelines)
+* [Licensing](#licensing)
+
+## Summary
+
+...
+
+## How to contribute
+
+...
+
+## How to report an issue or request a feature
+
+...
+
+## How to submit a code or documentation change
+
+...
+
+## Design philosophy
+
+...
+
+## Coding standards
+
+### Commit message guidelines
+
+All commit messages must follow the [Conventional Commits
+standard](https://www.conventionalcommits.org/en/v1.0.0/). This helps us maintain a
+clear and structured commit history, automate versioning, and generate changelogs
+effectively.
+
+To ensure compliance, this project includes:
+
+* A git commit-msg hook that validates your commit messages before they are accepted.
+
+  To activate the hook, you must have node installed and run `npm install`.
+
+* A GitHub Actions workflow that will enforce the Conventional Commit standard as
+  part of the continuous integration pipeline.
+
+  Any commit message that does not conform to the Conventional Commits standard will
+  cause the workflow to fail and not allow the PR to be merged.
+
+### Pull request guidelines
+
+All pull requests must be merged using rebase merges. This ensures that commit
+messages from the feature branch are preserved in the release branch, keeping the
+history clean and meaningful.
+
+## Licensing
+
+...

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@commitlint/cli": "^19.5.0",
+    "@commitlint/config-conventional": "^19.5.0",
+    "husky": "^9.1.0"
+  },
+  "scripts": {
+    "postinstall": "husky",
+    "prepare": "husky"
+  }
+}


### PR DESCRIPTION
Enforce [conventions commits](https://www.conventionalcommits.org/en/v1.0.0/) on this repostory.

See [main-branch/conventional_commit_sample](https://github.com/main-branch/conventional_commit_sample/blob/main/README.md) for more details.